### PR TITLE
Breaking Changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,17 @@
 import { createBot } from './bot'
 import { Context } from './types'
+import { handleScheduled } from './scheduled'
 
 export default {
   async fetch(request: Request, env: Context): Promise<Response> {
     return handleUpdate(request, env)
+  },
+  async scheduled(
+    event: ScheduledEvent,
+    env: Context,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    await handleScheduled(event.scheduledTime, env)
   }
 }
 
@@ -13,7 +21,6 @@ async function handleUpdate(request: Request, env: Context) {
       const bot = await createBot(env)
       const update = await request.json()
       await bot.handleUpdate(update as any)
-
       return new Response('OK')
     } catch (error) {
       return new Response('Invalid request', { status: 400 })

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -1,0 +1,48 @@
+import { Context } from './types'
+import { createBot } from './bot'
+
+export async function handleScheduled(
+  scheduledTime: number,
+  env: Context
+): Promise<void> {
+  const now = scheduledTime || Date.now()
+  const list = await env.CHAT_SESSIONS_STORAGE.list({ prefix: 'session_' })
+  const bot = await createBot(env, false)
+  const thirtyMinutes = 30 * 60 * 1000
+  for (const entry of list.keys) {
+    try {
+      const key = entry.name
+      const chatId = key.replace('session_', '')
+      const sessionDataJSON = await env.CHAT_SESSIONS_STORAGE.get(key)
+      if (!sessionDataJSON) continue
+      const sessionData = JSON.parse(sessionDataJSON)
+      const lastBotTime = sessionData.lastBotMessageTime
+        ? Number(sessionData.lastBotMessageTime)
+        : 0
+      const lastUserTime = sessionData.lastUserMessageTime
+        ? Number(sessionData.lastUserMessageTime)
+        : 0
+      const lastMessageFromBot = sessionData.lastMessageFromBot || false
+
+      if (
+        lastMessageFromBot &&
+        lastUserTime < lastBotTime &&
+        now - lastBotTime >= thirtyMinutes
+      ) {
+        continue
+      }
+      const reflection = sessionData.reflection || ''
+      const newMessageText =
+        reflection.trim() !== ''
+          ? reflection
+          : 'Небольшое напоминание: я здесь, пишите если хотите общаться!'
+      await bot.telegram.sendMessage(Number(chatId), newMessageText)
+      sessionData.lastBotMessageTime = Date.now().toString()
+      sessionData.lastMessageFromBot = true
+      sessionData.reflection = ''
+      await env.CHAT_SESSIONS_STORAGE.put(key, JSON.stringify(sessionData))
+    } catch (e) {
+      console.error('Error processing session', entry.name, e)
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface MemoryResponse {
   type: 'memory'
   content: string
 }
+
 export interface ChatMessage {
   name: string
   text: string
@@ -23,7 +24,11 @@ export interface SessionData {
   promptNotSet: boolean
   stickerNotSet: boolean
   replyChance: string
-  memories: Memory[] // Added memories array
+  memories: Memory[]
+  lastUserMessageTime?: string
+  lastBotMessageTime?: string
+  lastMessageFromBot?: boolean
+  reflection?: string
 }
 
 export interface Context {


### PR DESCRIPTION
<html><head></head><body><p>Отлично. Я подберу архитектуру и примеры кода, чтобы бот на Cloudflare Workers с использованием Node.js, TypeScript и библиотеки Telegraf:</p>
<ul>
<li>
<p>Получал все сообщения чата и сохранял их по chat_id</p>
</li>
<li>
<p>Отвечал только при упоминании или по собственной инициативе (раз в 30 минут)</p>
</li>
<li>
<p>Хранил "размышления" по каждому чату в отдельности (по chat_id)</p>
</li>
<li>
<p>Проверял, была ли реакция на его сообщение в течение 30 минут, прежде чем продолжить диалог</p>
</li>
</ul>
<p>Я предложу способ периодического запуска логики на Workers, архитектуру хранения (например, KV, R2, Durable Objects) и пример реализации. Дай немного времени, скоро вернусь с результатом.</p>

<h1>Реализация Telegram-бота на Cloudflare Workers (Node.js + TypeScript + Telegraf)</h1>
<h2>Запуск периодических задач (Scheduled Triggers)</h2>
<p>Чтобы бот выполнял периодические действия (раз в 30 минут), в Cloudflare Workers используются <strong>Scheduled Triggers</strong> – встроенный механизм cron. С помощью Cron Triggers можно привязать расписание (cron-выражение) к выполнению Worker-скрипта (<a href="https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule">Cron Triggers · Cloudflare Workers docs</a>). В коде Cloudflare Worker это реализуется через обработчик события <code>"scheduled"</code> (аналогично тому, как обрабатываются HTTP-запросы).</p>
<p><strong>Настройка расписания:</strong> в файле конфигурации Workers (например, <code>wrangler.toml</code>) указывается cron-выражение. Для запуска каждые 30 минут используйте выражение <code>*/30 * * * *</code> – оно означает запуск на 0-й и 30-й минуте каждого часа. Например:</p>
<pre><code class="language-toml">[triggers]
crons = ["*/30 * * * *"]
</code></pre>
<p>В коде Worker нужно определить обработчик события <code>scheduled</code>. В TypeScript это может выглядеть так:</p>
<pre><code class="language-ts">export default {
  async scheduled(controller, env, ctx) {
    // Код периодической задачи
    console.log("Scheduled event triggered");
  }
};
</code></pre>
<p>Когда наступает время по расписанию, Cloudflare запустит ваш Worker и вызовет этот обработчик. <strong>Scheduled Triggers</strong> идеально подходят для периодических задач, таких как обслуживание или регулярные опросы API (<a href="https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20are%20ideal%20for,the%20best%20use%20of%20Cloudflare%27s">Cron Triggers · Cloudflare Workers docs</a>) – в нашем случае, для регулярных сообщений бота.</p>
<h2>Хранение сообщений и "размышлений" по chat_id</h2>
<p>Для хранения данных бота на Cloudflare есть несколько вариантов: <strong>Workers KV</strong>, <strong>Durable Objects</strong>, <strong>R2</strong>, <strong>D1 (SQLite)</strong> и т.д. Оптимальным решением здесь будет использовать <strong>Workers KV</strong> для простого хранения состояния по каждому чату, а при необходимости – Cloudflare D1 или Durable Objects для более сложных случаев:</p>
<ul>
<li>
<p><strong>Workers KV</strong> – глобальное key-value хранилище. Подходит для хранения последнего сообщения, отметок времени и текста "размышлений" по каждому чату. KV обеспечивает очень быстрый доступ по ключу и простоту использования (но с eventually consistent консистентностью, что для нашего случая допустимо). Пример: можно хранить JSON-объект состояния для каждого чата под ключом <code>chat:&lt;ID&gt;:state</code>.</p>
</li>
<li>
<p><strong>Cloudflare D1</strong> – серверless SQL-база (SQLite). Если нужно хранить <strong>все</strong> сообщения (историю) или выполнять запросы (например, фильтрацию сообщений), можно завести таблицу сообщений (колонки: chat_id, user, text, timestamp) и таблицу размышлений. В KV при необходимости тоже можно сохранять каждое сообщение отдельно, но при большом объеме удобнее использовать D1 или R2 для логов.</p>
</li>
<li>
<p><strong>Durable Objects</strong> – для каждого чата можно создать Durable Object, который будет хранить состояние (сообщения, размышления) в памяти/хранилище с сильной консистентностью. DO также поддерживают <strong>Alarms</strong> (будильники), позволяющие планировать задачу для каждого отдельного объекта (<a href="https://blog.cloudflare.com/durable-objects-alarms/#:~:text=Durable%20Objects%20Alarms%20%E2%80%94%20a,a%20time%20in%20the%20future">Durable Objects Alarms — a wake-up call for your applications</a>). Это могло бы позволить реализовать периодические сообщения без глобального cron (каждый чат ставит будильник «через 30 минут» после последнего сообщения). Однако, Durable Objects сложнее в настройке, поэтому для начала можно обойтись общим Scheduled Trigger + KV.</p>
</li>
</ul>
<p><strong>Структура данных в хранилище (KV вариант):</strong></p>

Ключ (KV) | Содержимое (значение)
-- | --
chat:<ID>:state | JSON с состоянием чата: последние метки времени, флаг последнего отправителя, и пр. Например:{"lastUserMessageTime": 1680102030000, "lastBotMessageTime": 1680102000000, "lastMessageFromBot": true, "reflection": "Размышление..."}
chat:<ID>:messages:<N> | (Опционально) Отдельные сообщения. Например, можно сохранять каждое сообщение под уникальным ключом (с индексом или таймстемпом). В качестве упрощения можно не хранить все сообщения, либо сохранять только последние N сообщений в state.
chat:<ID>:reflection | (Если не включать в state) Текстовое поле «размышлений» бота по данному чату. Можно хранить отдельно, но также удобно хранить как поле reflection внутри state для атомарного обновления.


<p><strong>Примечание:</strong> В простейшем случае достаточно хранить в KV последнюю активность и размышления. <strong>Пример</strong>: когда приходит новое сообщение, обновляем запись <code>chat:&lt;ID&gt;:state</code> с <code>lastUserMessageTime</code>. Когда бот отправляет сообщение, обновляем <code>lastBotMessageTime</code> и флаг. Поле <code>reflection</code> может содержать любую информацию, которую бот хочет «помнить» между запусками – например, черновик следующего сообщения, summary обсуждения, или отметку «в прошлом сообщении я спросил X, жду ответа».</p>
<p>Cloudflare KV отлично справляется с быстрым сохранением таких данных. Например, фрагмент кода ниже сохраняет текст сообщения пользователя в KV и дублирует его в базу D1 (<a href="https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=%2F%2F%20Store%20user%20message%20in,text">Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community</a>):</p>
<pre><code class="language-js">// Сохранение текста полученного сообщения в KV (ключ = chatId)
await MY_KV_NAMESPACE.put(chatId, message.text)

// Сохранение сообщения в таблицу D1 (для истории)
await MY_D1_DATABASE.query(
  `INSERT INTO messages (chat_id, message) VALUES (?, ?)`,
  [chatId, message.text]
)
</code></pre>
<p>В нашем случае мы будем сохранять не только текст, но и дополнительные метаданные (время, признак от бота ли сообщение и т.д.) под организованными ключами.</p>
<h2>Обработка входящих сообщений (Webhook)</h2>
<p>Telegram-бот будет получать обновления через <strong>webhook</strong>: мы зарегистрируем URL Cloudflare Worker в BotFather (например: <code>https://&lt;your-subdomain&gt;.workers.dev/webhook</code>), и Telegram будет делать HTTP POST с обновлением. Cloudflare Worker должен обработать запрос в событии <code>fetch</code>.</p>
<p>С использованием <strong>Telegraf</strong> в среде Cloudflare Workers необходимо работать в режиме webhook (не вызывать <code>bot.launch()</code>, который пытается запустить длинный опрос). Вместо этого можно напрямую вызывать метод <code>bot.handleUpdate(update)</code> для обработки входящих данных (<a href="https://github.com/telegraf/telegraf#:~:text=GitHub%20github,or%20times%20out%2C%20Telegraf">telegraf/telegraf: Modern Telegram Bot Framework for Node.js - GitHub</a>), либо самостоятельно разбирать <code>update</code> и вызывать нужные методы Telegraf. Ниже приведен пример организации кода обработчика входящего запроса:</p>
<pre><code class="language-ts">import { Telegraf } from 'telegraf'

// Инициализация бота (токен хранится в переменных окружения Workers)
const bot = new Telegraf(&lt;BOT_TOKEN&gt;)
// Можно настроить обработчики через Telegraf, например:
// bot.on('text', ctx =&gt; { ... }); 
// bot.command('start', ...); 
// Но помним не вызывать bot.launch()

// Основной обработчик HTTP запросов
addEventListener('fetch', event =&gt; {
  event.respondWith(handleRequest(event.request, event));
});

async function handleRequest(request: Request, event: FetchEvent): Promise&lt;Response&gt; {
  const url = new URL(request.url);
  if (request.method === 'POST' &amp;&amp; url.pathname === '/webhook') {
    const update = await request.json();
    await handleTelegramUpdate(update);  // обработаем обновление
    return new Response('OK');  // быстро возвращаем ОК Telegram
  }
  return new Response('Not found', { status: 404 });
}

// Обработка полученного обновления от Telegram
async function handleTelegramUpdate(update: any) {
  if (!update.message) return;  // обработаем только сообщения
  const msg = update.message;
  const chatId = msg.chat.id;
  const sender = msg.from;
  
  // Загрузить текущее состояние чата из KV (если есть)
  const stateKey = `chat:${chatId}:state`;
  let state = await CHAT_KV.get(stateKey, { type: 'json' }) || {};  // CHAT_KV - привязанное KV-хранилище
  
  // Обновить сохраненные сообщения/размышления
  const text = msg.text || ''; 
  if (!sender.is_bot) {
    // Сохраняем сообщение пользователя (пример - последнее сообщение и время)
    state.lastUserMessageTime = Date.now();
    state.lastMessageFromBot = false;
    // Можно также добавить его текст в историю/размышления:
    // например, обновить state.reflection на основе содержания сообщения
    state.reflection = updateReflectionOnUserMessage(state.reflection, text);
  }
  
  // Проверяем, было ли явное упоминание бота или личный чат
  const botUsername = '&lt;USERNAME_BOT&gt;';  // имя бота, можно хранить в env
  const mentioned = text.includes('@' + botUsername) || msg.chat.type === 'private';
  if (mentioned) {
    // Формируем ответ (можно использовать данные размышлений и текста пользователя)
    const replyText = generateReply(text, state.reflection, sender);
    // Отправляем сообщение через Telegram Bot API
    await sendMessage(chatId, replyText);
    // Обновляем состояние бота для этого чата
    state.lastBotMessageTime = Date.now();
    state.lastMessageFromBot = true;
    // Обновляем "размышления" бота на основе того, что он ответил
    state.reflection = updateReflectionAfterReply(state.reflection, replyText);
  }
  
  // Сохраняем обновленное состояние чата обратно в KV
  await CHAT_KV.put(stateKey, JSON.stringify(state));
}

// Функция отправки сообщения через Bot API
async function sendMessage(chatId: number, text: string): Promise&lt;void&gt; {
  const url = `https://api.telegram.org/bot${&lt;BOT_TOKEN&gt;}/sendMessage`;
  await fetch(url, {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ chat_id: chatId, text: text })
  });
}
</code></pre>
<p>В этом коде происходит следующее:</p>
<ul>
<li>
<p>При поступлении запроса на путь <code>/webhook</code> бот парсит JSON обновление. Далее:</p>
<ul>
<li>
<p><strong>Сохранение сообщения:</strong> Если пришло сообщение (<code>update.message</code>), обновляем хранилище KV для соответствующего <code>chat_id</code>. В простейшем случае мы записываем время последнего пользовательского сообщения (<code>lastUserMessageTime</code>) и сбрасываем флаг <code>lastMessageFromBot</code>. Также можно добавить текст сообщения в "размышления" (например, чтобы бот помнил контекст беседы).</p>
</li>
<li>
<p><strong>Обработка упоминания:</strong> Если сообщение содержит упоминание бота (либо это личный чат, где все сообщения адресованы боту), бот формирует ответ. Здесь функция <code>generateReply</code> может быть любая ваша логика ответа – например, эхо-бот, либо анализ текста пользователя с учетом <code>state.reflection</code>. <strong>Пример:</strong> бот может просто ответить: <code>"Привет, ${sender.first_name}, вы упомянули меня!"</code> или что-то контекстное.</p>
</li>
<li>
<p><strong>Отправка ответа:</strong> Для отправки используется <code>sendMessage</code> – она вызывает Telegram Bot API метод <strong>sendMessage</strong> через <code>fetch</code>. Пример запроса показан выше: мы отправляем POST на <code>https://api.telegram.org/bot&lt;token&gt;/sendMessage</code> с JSON телом, указав <code>chat_id</code> и <code>text</code> (<a href="https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text">Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community</a>). Библиотека Telegraf тоже позволяет отправлять сообщение, например <code>ctx.reply()</code> или <code>bot.telegram.sendMessage</code>, но внутри это эквивалентно HTTP вызову.</p>
</li>
<li>
<p><strong>Обновление состояния бота:</strong> После отправки ответа сохраняем время этого отправления (<code>lastBotMessageTime</code>) и помечаем, что последнее сообщение в чате от бота (<code>lastMessageFromBot = true</code>). Также можно обновить "размышления" – например, бот может записать себе, о чем он спросил, чтобы потом проверить, ответили ему или нет.</p>
</li>
</ul>
</li>
<li>
<p><strong>Возврат ответа webhook:</strong> Мы сразу возвращаем <code>Response('OK')</code>. Telegram ждет ответ 200 OK чтобы считать webhook успешным. Бизнес-логику ответа мы выполнили асинхронно (но <em>до</em> отправки ответа), либо могли запустить через <code>event.waitUntil</code> для невидимого фонового выполнения. В данном случае, код успеет выполниться быстро (несколько KV операций и один запрос к Telegram API), что укладывается в ограничения Workers.</p>
</li>
</ul>
<blockquote>
<p>💡 <strong>Совет:</strong> Telegram по умолчанию <strong>не присылает</strong> боту обновления о сообщениях, которые <em>сам бот</em> отправил. Поэтому, когда бот отправляет сообщение, мы <strong>сами</strong> обновляем состояние (<code>lastBotMessageTime</code> и т.п.). Пользовательские сообщения приходят через webhook и обновляют <code>lastUserMessageTime</code>. Таким образом, мы всегда знаем, кто был автором последнего сообщения и когда.</p>
</blockquote>
<h2>Периодическая проверка и отправка сообщений</h2>
<p>Теперь разберем, как реализовать поведение бота "по собственной инициативе" каждые 30 минут с учетом описанных условий. Эту логику будем запускать в обработчике <code>scheduled</code> (через Cron Trigger).</p>
<p><strong>Алгоритм (каждые 30 минут):</strong></p>
<ol>
<li>
<p><strong>Получение списка чатов:</strong> Бот должен знать, в каких чатах он состоит (чтобы знать, куда потенциально писать). Можно хранить список <code>chat_id</code> всех активных чатов. Проще всего – добавлять <code>chat_id</code> в KV при первом появлении и хранить, например, в отдельном ключе или использовать префиксы. Например, если все ключи состояния начинаются с <code>chat:</code>, мы можем получить их список через <code>CHAT_KV.list({ prefix: "chat:" })</code>. Этот список итерируем, выбирая каждый <code>chat:&lt;ID&gt;:state</code>.</p>
</li>
<li>
<p><strong>Проверка условий ответа:</strong> Для каждого чата из списка проверяем условие: <em>«Является ли последнее сообщение в чате сообщением бота, оставшимся без ответа пользователя в течение 30 минут?»</em>. Конкретно, нам нужны поля <code>lastBotMessageTime</code>, <code>lastUserMessageTime</code>, <code>lastMessageFromBot</code>:</p>
<ul>
<li>
<p>Если <code>lastMessageFromBot == true</code> <strong>и</strong> с момента <code>lastBotMessageTime</code> прошло ≥30 минут <strong>и</strong> <code>lastUserMessageTime</code> все еще ≤ <code>lastBotMessageTime</code> (то есть после последнего бот-сообщения не было нового пользовательского), <strong>то бот НЕ отправляет новое сообщение</strong>. Иначе говоря, он ждет, пока не появится какая-то активность пользователя в этом чате.</p>
</li>
<li>
<p>В противном случае (либо последнее сообщение было от пользователя, либо бот получил ответ/какую-то активность после своего последнего сообщения), бот <strong>может отправить</strong> новое сообщение.</p>
</li>
</ul>
</li>
<li>
<p><strong>Отправка периодического сообщения:</strong> Если условия позволяют, бот генерирует новое сообщение для чата. Здесь можно использовать поле "размышления" в качестве основы. Например, размышление может быть заготовкой фразы или вопроса, который бот хотел ранее отправить. Если размышление пустое, бот может придумать новое сообщение (например, случайную фразу, либо просуммировать последние сообщения и написать что-то релевантное). Отправляем это сообщение через <code>sendMessage</code> (как и в случае упоминания).</p>
</li>
<li>
<p><strong>Обновление состояния:</strong> После отправки обновляем <code>lastBotMessageTime</code>, ставим <code>lastMessageFromBot = true</code>. Также обновляем или очищаем "размышления". Возможно, бот будет генерировать новые "размышления" после отправки – например, если бот задал вопрос, он может сохранить в <code>reflection</code> заметку: <em>"я спросил про погоду, жду ответ"</em>.</p>
</li>
</ol>
<p>Ниже приведен пример реализации обработчика <code>scheduled</code> с описанной логикой:</p>
<pre><code class="language-ts">addEventListener('scheduled', event =&gt; {
  event.waitUntil(handleScheduled(event.scheduledTime));
});

async function handleScheduled(triggerTime: number) {
  const now = triggerTime || Date.now();
  // Получаем список всех ключей с префиксом "chat:"
  const list = await CHAT_KV.list({ prefix: 'chat:' });
  for (const entry of list.keys) {
    if (!entry.name.endsWith(':state')) continue;  // нас интересуют только ключи state
    const chatState = await CHAT_KV.get(entry.name, { type: 'json' });
    if (!chatState) continue;
    const chatId = chatState.chatId || entry.name.split(':')[1];  // извлекаем ID чата
    
    const lastBotTime = chatState.lastBotMessageTime || 0;
    const lastUserTime = chatState.lastUserMessageTime || 0;
    const lastMsgFromBot = chatState.lastMessageFromBot;
    
    // Проверяем условие: последнее сообщение от бота и нет ответа пользователя в 30-минутный интервал
    const thirtyMinutes = 30 * 60 * 1000;
    if (lastMsgFromBot &amp;&amp; lastUserTime &lt; lastBotTime &amp;&amp; (now - lastBotTime) &gt;= thirtyMinutes) {
      // Бот отправил последнее сообщение и в течение 30 минут не было ответа -&gt; пропускаем отправку
      continue;
    }
    
    // Иначе – либо последнее сообщение не от бота, либо бот получил ответ/активность =&gt; можно слать новое сообщение
    const reflection = chatState.reflection || "";
    const newMessageText = generatePeriodicMessage(reflection, chatState);
    await sendMessage(chatId, newMessageText);
    
    // Обновляем состояние после отправки
    chatState.lastBotMessageTime = Date.now();
    chatState.lastMessageFromBot = true;
    // Обновляем "размышления" – например, бот обнуляет или формирует новое на основе реакции
    chatState.reflection = updateReflectionAfterSending(reflection, newMessageText);
    await CHAT_KV.put(entry.name, JSON.stringify(chatState));
  }
}
</code></pre>
<p><strong>Что делает этот код:</strong></p>
<ul>
<li>
<p>Итерируется по всем сохраненным чатам.</p>
</li>
<li>
<p>Для каждого проверяется, не было ли у бота последним слово без ответа. Если бот “разговаривает сам с собой” (т.е. его последнее сообщение повисло в пустоте), он <strong>не будет</strong> генерировать новое сообщение (<code>continue</code>). Благодаря этому условию, бот не заспамит молчащий чат: он дождется, когда кто-то что-то напишет. Как только в чат прилетит любое новое сообщение от пользователя (тем самым обновится <code>lastUserMessageTime</code> и <code>lastMessageFromBot</code> станет false), при следующем срабатывании cron бот снова активируется.</p>
</li>
<li>
<p>Если же последнее сообщение было от пользователя <strong>или</strong> бот получил ответ/реплику после своего предыдущего поста, бот формирует новое <strong>периодическое сообщение</strong>. Содержание можно придумать на основе <code>reflection</code> или других данных. (Реализация <code>generatePeriodicMessage</code> зависит от задачи: например, бот может вести небольшую беседу сам с собой, либо напоминать о чем-то через равные интервалы.)</p>
</li>
<li>
<p>Бот отправляет сообщение в чат (<code>sendMessage(chatId, text)</code> – та же функция отправки через Telegram API).</p>
</li>
<li>
<p>Затем бот обновляет свое сохраненное состояние в KV: отмечает время отправки и факт, что последнее сообщение теперь от него, а также обновляет "размышления". <strong>Пример обновления размышлений:</strong> если бот задал вопрос и ожидает ответ, можно записать в размышления что-то вроде: <em>"спросил про погоду, жду ответа"</em>; если бот просто поделился фактом, можно очистить или изменить размышление под следующую тему.</p>
</li>
</ul>
<p>Таким образом, с каждым запуском по расписанию бот принимает решение – говорить или молчать – исходя из активности в чате и своей «памяти» о предыдущих попытках.</p>
<h2>Итоговая структура решения</h2>
<ul>
<li>
<p><strong>Cloudflare Worker</strong> на TypeScript с библиотекой Telegraf, развернутый в режиме webhook. Бот регистрирует webhook URL с помощью BotFather (или скриптом, аналогично шаг (<a href="https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=,5%3A%20Configure%20Telegram%20Webhook">Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community</a>)】).</p>
</li>
<li>
<p><strong>Обработка входящих сообщений:</strong> Worker (через Telegraf или вручную) получает обновления, сохраняет каждое сообщение в хранилище (KV/D1) с привязкой к <code>chat_id</code>, обновляет время последней активности. При упоминании бота – формирует и отправляет ответ, обновляя состояние.</p>
</li>
<li>
<p><strong>Хранение состояния:</strong> Используется KV (и/или D1) для хранения информации по каждому чату:</p>
<ul>
<li>
<p>временные метки последнего сообщения от пользователя и от бота,</p>
</li>
<li>
<p>флаг, кто был автором последнего сообщения,</p>
</li>
<li>
<p>текстовые "размышления" бота (произвольные заметки или контекст).</p>
</li>
</ul>
</li>
<li>
<p><strong>Периодическая логика:</strong> С помощью <strong>Scheduled Triggers</strong> Cloudflare запускает бот раз в 30 минут. Бот просматривает состояния всех чатов:</p>
<ul>
<li>
<p>Если бот ранее написал и ему не ответили в течение 30 минут, он <strong>пропускает</strong> отправку (ждет пользовательского сообщения).</p>
</li>
<li>
<p>Иначе бот <strong>отправляет</strong> новое сообщение от себя и обновляет "размышления".</p>
</li>
</ul>
</li>
<li>
<p><strong>Пример поведения:</strong> допустим, бот настроен каждые 30 минут присылать шутку. Если в каком-то чате в 12:00 бот рассказал шутку, но до 12:30 никто ничего не написал, то в 12:30 бот <strong>не будет</strong> рассказывать новую (чтобы не идти монологом). Он дождется, например, до 14:00, когда в чат кто-то что-то напишет; после этого, на ближайшем запуске (14:30) бот снова вставит свою реплику.</p>
</li>
</ul>
<p>Такое решение использует бессерверную природу Cloudflare Workers: бот масштабируется автоматически, <strong>не требует постоянного сервера</strong>, а периодические задачи выполняются Cloudflare по расписани (<a href="https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule">Cron Triggers · Cloudflare Workers docs</a>)】. Хранение на Workers KV/D1 обеспечивает сохранность контекста между вызовами. Вся логика (упоминания, паузы в ожидании ответа, размышления) инкапсулирована в коде Workers.</p>
<p><strong>Диаграмма взаимодействия (общая):</strong></p>
<ol>
<li>
<p><strong>Пользовательское сообщение →</strong> Telegram пересылает обновление на ваш Cloudflare Worker (webhook).</p>
</li>
<li>
<p><strong>Cloudflare Worker (fetch) →</strong> сохраняет сообщение в KV/D1, обновляет состояние. Если необходимо – отправляет ответ через Telegram API.</p>
</li>
<li>
<p><strong>Cloudflare Worker (scheduled trigger каждые 30 мин) →</strong> просматривает состояния чатовых сессий:</p>
<ul>
<li>
<p>решает, куда отправить сообщение согласно логике,</p>
</li>
<li>
<p>отправляет сообщения через Telegram API от имени бота.</p>
</li>
</ul>
</li>
<li>
<p><strong>Telegram</strong> доставляет эти бот-сообщения в чаты. (Замечание: бот не получает webhook на собственные сообщения, поэтому обновляет своё состояние локально.)</p>
</li>
<li>
<p><strong>Цикл повторяется...</strong> Пользовательская активность сбрасывает таймер ожидания, бот реагирует упоминаниями немедленно и периодически – по расписанию с учетом условий.</p>
</li>
</ol>
<p>Используя данный подход, мы получаем неблокирующего Telegram-бота, работающего полностью в серверless-среде. Он <strong>присутствует в чатах</strong> и ведет историю сообщений, <strong>отвечает на упоминания</strong> через Telegraf-контекст или прямые вызовы API, а также способен <strong>инициировать сообщения</strong> по таймеру, не нарушая удобство общения (благодаря проверке на отсутствие ответа). Все это реализовано средствами Cloudflare Workers, что обеспечивает высокую масштабируемость и отсутствие необходимости управлять собственным сервером.</p>
<p><strong>Источники:</strong></p>
<ul>
<li>
<p>Cloudflare Workers Cron Triggers – документация по запуску задач по расписани (<a href="https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule">Cron Triggers · Cloudflare Workers docs</a>)】</p>
</li>
<li>
<p>Пример Telegram-бота на Cloudflare Workers с хранением данных в KV и D (<a href="https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=if%20%28pathname%20%3D%3D%3D%20%27%2Fwebhook%27%29%20,%27Hello%20from%20Cloudflare%20Workers">Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community</a>) (<a href="https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text">Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community</a>)】 (иллюстрирует обработку webhook и отправку сообщений).</p>
</li>
</ul></body></html>Отлично. Я подберу архитектуру и примеры кода, чтобы бот на Cloudflare Workers с использованием Node.js, TypeScript и библиотеки Telegraf:

- Получал все сообщения чата и сохранял их по chat_id
- Отвечал только при упоминании или по собственной инициативе (раз в 30 минут)
- Хранил "размышления" по каждому чату в отдельности (по chat_id)
- Проверял, была ли реакция на его сообщение в течение 30 минут, прежде чем продолжить диалог

Я предложу способ периодического запуска логики на Workers, архитектуру хранения (например, KV, R2, Durable Objects) и пример реализации. Дай немного времени, скоро вернусь с результатом.

# Реализация Telegram-бота на Cloudflare Workers (Node.js + TypeScript + Telegraf)

## Запуск периодических задач (Scheduled Triggers)

Чтобы бот выполнял периодические действия (раз в 30 минут), в Cloudflare Workers используются **Scheduled Triggers** – встроенный механизм cron. С помощью Cron Triggers можно привязать расписание (cron-выражение) к выполнению Worker-скрипта ([[Cron Triggers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule)](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule)). В коде Cloudflare Worker это реализуется через обработчик события `"scheduled"` (аналогично тому, как обрабатываются HTTP-запросы). 

**Настройка расписания:** в файле конфигурации Workers (например, `wrangler.toml`) указывается cron-выражение. Для запуска каждые 30 минут используйте выражение `*/30 * * * *` – оно означает запуск на 0-й и 30-й минуте каждого часа. Например:

```toml
[triggers]
crons = ["*/30 * * * *"]
```

В коде Worker нужно определить обработчик события `scheduled`. В TypeScript это может выглядеть так: 

```ts
export default {
  async scheduled(controller, env, ctx) {
    // Код периодической задачи
    console.log("Scheduled event triggered");
  }
};
``` 

Когда наступает время по расписанию, Cloudflare запустит ваш Worker и вызовет этот обработчик. **Scheduled Triggers** идеально подходят для периодических задач, таких как обслуживание или регулярные опросы API ([[Cron Triggers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20are%20ideal%20for,the%20best%20use%20of%20Cloudflare%27s)](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20are%20ideal%20for,the%20best%20use%20of%20Cloudflare%27s)) – в нашем случае, для регулярных сообщений бота.

## Хранение сообщений и "размышлений" по chat_id

Для хранения данных бота на Cloudflare есть несколько вариантов: **Workers KV**, **Durable Objects**, **R2**, **D1 (SQLite)** и т.д. Оптимальным решением здесь будет использовать **Workers KV** для простого хранения состояния по каждому чату, а при необходимости – Cloudflare D1 или Durable Objects для более сложных случаев:

- **Workers KV** – глобальное key-value хранилище. Подходит для хранения последнего сообщения, отметок времени и текста "размышлений" по каждому чату. KV обеспечивает очень быстрый доступ по ключу и простоту использования (но с eventually consistent консистентностью, что для нашего случая допустимо). Пример: можно хранить JSON-объект состояния для каждого чата под ключом `chat:<ID>:state`.  
- **Cloudflare D1** – серверless SQL-база (SQLite). Если нужно хранить **все** сообщения (историю) или выполнять запросы (например, фильтрацию сообщений), можно завести таблицу сообщений (колонки: chat_id, user, text, timestamp) и таблицу размышлений. В KV при необходимости тоже можно сохранять каждое сообщение отдельно, но при большом объеме удобнее использовать D1 или R2 для логов.  
- **Durable Objects** – для каждого чата можно создать Durable Object, который будет хранить состояние (сообщения, размышления) в памяти/хранилище с сильной консистентностью. DO также поддерживают **Alarms** (будильники), позволяющие планировать задачу для каждого отдельного объекта ([[Durable Objects Alarms — a wake-up call for your applications](https://blog.cloudflare.com/durable-objects-alarms/#:~:text=Durable%20Objects%20Alarms%20%E2%80%94%20a,a%20time%20in%20the%20future)](https://blog.cloudflare.com/durable-objects-alarms/#:~:text=Durable%20Objects%20Alarms%20%E2%80%94%20a,a%20time%20in%20the%20future)). Это могло бы позволить реализовать периодические сообщения без глобального cron (каждый чат ставит будильник «через 30 минут» после последнего сообщения). Однако, Durable Objects сложнее в настройке, поэтому для начала можно обойтись общим Scheduled Trigger + KV.

**Структура данных в хранилище (KV вариант):**

| **Ключ (KV)**            | **Содержимое (значение)**                                                                                                                                       |
|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `chat:<ID>:state`        | JSON с состоянием чата: последние метки времени, флаг последнего отправителя, и пр. Например:<br>`{"lastUserMessageTime": 1680102030000, "lastBotMessageTime": 1680102000000, "lastMessageFromBot": true, "reflection": "Размышление..."}` |
| `chat:<ID>:messages:<N>` | *(Опционально)* Отдельные сообщения. Например, можно сохранять каждое сообщение под уникальным ключом (с индексом или таймстемпом). В качестве упрощения можно не хранить все сообщения, либо сохранять только последние N сообщений в `state`. |
| `chat:<ID>:reflection`   | *(Если не включать в state)* Текстовое поле «размышлений» бота по данному чату. Можно хранить отдельно, но также удобно хранить как поле `reflection` внутри `state` для атомарного обновления. |

**Примечание:** В простейшем случае достаточно хранить в KV последнюю активность и размышления. **Пример**: когда приходит новое сообщение, обновляем запись `chat:<ID>:state` с `lastUserMessageTime`. Когда бот отправляет сообщение, обновляем `lastBotMessageTime` и флаг. Поле `reflection` может содержать любую информацию, которую бот хочет «помнить» между запусками – например, черновик следующего сообщения, summary обсуждения, или отметку «в прошлом сообщении я спросил X, жду ответа».

Cloudflare KV отлично справляется с быстрым сохранением таких данных. Например, фрагмент кода ниже сохраняет текст сообщения пользователя в KV и дублирует его в базу D1 ([[Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=%2F%2F%20Store%20user%20message%20in,text)](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=%2F%2F%20Store%20user%20message%20in,text)):

```js
// Сохранение текста полученного сообщения в KV (ключ = chatId)
await MY_KV_NAMESPACE.put(chatId, message.text)

// Сохранение сообщения в таблицу D1 (для истории)
await MY_D1_DATABASE.query(
  `INSERT INTO messages (chat_id, message) VALUES (?, ?)`,
  [chatId, message.text]
)
``` 

В нашем случае мы будем сохранять не только текст, но и дополнительные метаданные (время, признак от бота ли сообщение и т.д.) под организованными ключами.

## Обработка входящих сообщений (Webhook)

Telegram-бот будет получать обновления через **webhook**: мы зарегистрируем URL Cloudflare Worker в BotFather (например: `https://<your-subdomain>.workers.dev/webhook`), и Telegram будет делать HTTP POST с обновлением. Cloudflare Worker должен обработать запрос в событии `fetch`.

С использованием **Telegraf** в среде Cloudflare Workers необходимо работать в режиме webhook (не вызывать `bot.launch()`, который пытается запустить длинный опрос). Вместо этого можно напрямую вызывать метод `bot.handleUpdate(update)` для обработки входящих данных ([[telegraf/telegraf: Modern Telegram Bot Framework for Node.js - GitHub](https://github.com/telegraf/telegraf#:~:text=GitHub%20github,or%20times%20out%2C%20Telegraf)](https://github.com/telegraf/telegraf#:~:text=GitHub%20github,or%20times%20out%2C%20Telegraf)), либо самостоятельно разбирать `update` и вызывать нужные методы Telegraf. Ниже приведен пример организации кода обработчика входящего запроса:

```ts
import { Telegraf } from 'telegraf'

// Инициализация бота (токен хранится в переменных окружения Workers)
const bot = new Telegraf(<BOT_TOKEN>)
// Можно настроить обработчики через Telegraf, например:
// bot.on('text', ctx => { ... }); 
// bot.command('start', ...); 
// Но помним не вызывать bot.launch()

// Основной обработчик HTTP запросов
addEventListener('fetch', event => {
  event.respondWith(handleRequest(event.request, event));
});

async function handleRequest(request: Request, event: FetchEvent): Promise<Response> {
  const url = new URL(request.url);
  if (request.method === 'POST' && url.pathname === '/webhook') {
    const update = await request.json();
    await handleTelegramUpdate(update);  // обработаем обновление
    return new Response('OK');  // быстро возвращаем ОК Telegram
  }
  return new Response('Not found', { status: 404 });
}

// Обработка полученного обновления от Telegram
async function handleTelegramUpdate(update: any) {
  if (!update.message) return;  // обработаем только сообщения
  const msg = update.message;
  const chatId = msg.chat.id;
  const sender = msg.from;
  
  // Загрузить текущее состояние чата из KV (если есть)
  const stateKey = `chat:${chatId}:state`;
  let state = await CHAT_KV.get(stateKey, { type: 'json' }) || {};  // CHAT_KV - привязанное KV-хранилище
  
  // Обновить сохраненные сообщения/размышления
  const text = msg.text || ''; 
  if (!sender.is_bot) {
    // Сохраняем сообщение пользователя (пример - последнее сообщение и время)
    state.lastUserMessageTime = Date.now();
    state.lastMessageFromBot = false;
    // Можно также добавить его текст в историю/размышления:
    // например, обновить state.reflection на основе содержания сообщения
    state.reflection = updateReflectionOnUserMessage(state.reflection, text);
  }
  
  // Проверяем, было ли явное упоминание бота или личный чат
  const botUsername = '<USERNAME_BOT>';  // имя бота, можно хранить в env
  const mentioned = text.includes('@' + botUsername) || msg.chat.type === 'private';
  if (mentioned) {
    // Формируем ответ (можно использовать данные размышлений и текста пользователя)
    const replyText = generateReply(text, state.reflection, sender);
    // Отправляем сообщение через Telegram Bot API
    await sendMessage(chatId, replyText);
    // Обновляем состояние бота для этого чата
    state.lastBotMessageTime = Date.now();
    state.lastMessageFromBot = true;
    // Обновляем "размышления" бота на основе того, что он ответил
    state.reflection = updateReflectionAfterReply(state.reflection, replyText);
  }
  
  // Сохраняем обновленное состояние чата обратно в KV
  await CHAT_KV.put(stateKey, JSON.stringify(state));
}

// Функция отправки сообщения через Bot API
async function sendMessage(chatId: number, text: string): Promise<void> {
  const url = `https://api.telegram.org/bot${<BOT_TOKEN>}/sendMessage`;
  await fetch(url, {
    method: 'POST',
    headers: { 'Content-Type': 'application/json' },
    body: JSON.stringify({ chat_id: chatId, text: text })
  });
}
```

В этом коде происходит следующее:

- При поступлении запроса на путь `/webhook` бот парсит JSON обновление. Далее:
  - **Сохранение сообщения:** Если пришло сообщение (`update.message`), обновляем хранилище KV для соответствующего `chat_id`. В простейшем случае мы записываем время последнего пользовательского сообщения (`lastUserMessageTime`) и сбрасываем флаг `lastMessageFromBot`. Также можно добавить текст сообщения в "размышления" (например, чтобы бот помнил контекст беседы).
  - **Обработка упоминания:** Если сообщение содержит упоминание бота (либо это личный чат, где все сообщения адресованы боту), бот формирует ответ. Здесь функция `generateReply` может быть любая ваша логика ответа – например, эхо-бот, либо анализ текста пользователя с учетом `state.reflection`. **Пример:** бот может просто ответить: `"Привет, ${sender.first_name}, вы упомянули меня!"` или что-то контекстное.
  - **Отправка ответа:** Для отправки используется `sendMessage` – она вызывает Telegram Bot API метод **sendMessage** через `fetch`. Пример запроса показан выше: мы отправляем POST на `https://api.telegram.org/bot<token>/sendMessage` с JSON телом, указав `chat_id` и `text` ([[Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text)](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text)). Библиотека Telegraf тоже позволяет отправлять сообщение, например `ctx.reply()` или `bot.telegram.sendMessage`, но внутри это эквивалентно HTTP вызову.
  - **Обновление состояния бота:** После отправки ответа сохраняем время этого отправления (`lastBotMessageTime`) и помечаем, что последнее сообщение в чате от бота (`lastMessageFromBot = true`). Также можно обновить "размышления" – например, бот может записать себе, о чем он спросил, чтобы потом проверить, ответили ему или нет.
- **Возврат ответа webhook:** Мы сразу возвращаем `Response('OK')`. Telegram ждет ответ 200 OK чтобы считать webhook успешным. Бизнес-логику ответа мы выполнили асинхронно (но *до* отправки ответа), либо могли запустить через `event.waitUntil` для невидимого фонового выполнения. В данном случае, код успеет выполниться быстро (несколько KV операций и один запрос к Telegram API), что укладывается в ограничения Workers.

> 💡 **Совет:** Telegram по умолчанию **не присылает** боту обновления о сообщениях, которые *сам бот* отправил. Поэтому, когда бот отправляет сообщение, мы **сами** обновляем состояние (`lastBotMessageTime` и т.п.). Пользовательские сообщения приходят через webhook и обновляют `lastUserMessageTime`. Таким образом, мы всегда знаем, кто был автором последнего сообщения и когда.

## Периодическая проверка и отправка сообщений

Теперь разберем, как реализовать поведение бота "по собственной инициативе" каждые 30 минут с учетом описанных условий. Эту логику будем запускать в обработчике `scheduled` (через Cron Trigger).

**Алгоритм (каждые 30 минут):**

1. **Получение списка чатов:** Бот должен знать, в каких чатах он состоит (чтобы знать, куда потенциально писать). Можно хранить список `chat_id` всех активных чатов. Проще всего – добавлять `chat_id` в KV при первом появлении и хранить, например, в отдельном ключе или использовать префиксы. Например, если все ключи состояния начинаются с `chat:`, мы можем получить их список через `CHAT_KV.list({ prefix: "chat:" })`. Этот список итерируем, выбирая каждый `chat:<ID>:state`. 
2. **Проверка условий ответа:** Для каждого чата из списка проверяем условие: *«Является ли последнее сообщение в чате сообщением бота, оставшимся без ответа пользователя в течение 30 минут?»*. Конкретно, нам нужны поля `lastBotMessageTime`, `lastUserMessageTime`, `lastMessageFromBot`:
   - Если `lastMessageFromBot == true` **и** с момента `lastBotMessageTime` прошло ≥30 минут **и** `lastUserMessageTime` все еще ≤ `lastBotMessageTime` (то есть после последнего бот-сообщения не было нового пользовательского), **то бот НЕ отправляет новое сообщение**. Иначе говоря, он ждет, пока не появится какая-то активность пользователя в этом чате. 
   - В противном случае (либо последнее сообщение было от пользователя, либо бот получил ответ/какую-то активность после своего последнего сообщения), бот **может отправить** новое сообщение.
3. **Отправка периодического сообщения:** Если условия позволяют, бот генерирует новое сообщение для чата. Здесь можно использовать поле "размышления" в качестве основы. Например, размышление может быть заготовкой фразы или вопроса, который бот хотел ранее отправить. Если размышление пустое, бот может придумать новое сообщение (например, случайную фразу, либо просуммировать последние сообщения и написать что-то релевантное). Отправляем это сообщение через `sendMessage` (как и в случае упоминания).
4. **Обновление состояния:** После отправки обновляем `lastBotMessageTime`, ставим `lastMessageFromBot = true`. Также обновляем или очищаем "размышления". Возможно, бот будет генерировать новые "размышления" после отправки – например, если бот задал вопрос, он может сохранить в `reflection` заметку: *"я спросил про погоду, жду ответ"*.

Ниже приведен пример реализации обработчика `scheduled` с описанной логикой:

```ts
addEventListener('scheduled', event => {
  event.waitUntil(handleScheduled(event.scheduledTime));
});

async function handleScheduled(triggerTime: number) {
  const now = triggerTime || Date.now();
  // Получаем список всех ключей с префиксом "chat:"
  const list = await CHAT_KV.list({ prefix: 'chat:' });
  for (const entry of list.keys) {
    if (!entry.name.endsWith(':state')) continue;  // нас интересуют только ключи state
    const chatState = await CHAT_KV.get(entry.name, { type: 'json' });
    if (!chatState) continue;
    const chatId = chatState.chatId || entry.name.split(':')[1];  // извлекаем ID чата
    
    const lastBotTime = chatState.lastBotMessageTime || 0;
    const lastUserTime = chatState.lastUserMessageTime || 0;
    const lastMsgFromBot = chatState.lastMessageFromBot;
    
    // Проверяем условие: последнее сообщение от бота и нет ответа пользователя в 30-минутный интервал
    const thirtyMinutes = 30 * 60 * 1000;
    if (lastMsgFromBot && lastUserTime < lastBotTime && (now - lastBotTime) >= thirtyMinutes) {
      // Бот отправил последнее сообщение и в течение 30 минут не было ответа -> пропускаем отправку
      continue;
    }
    
    // Иначе – либо последнее сообщение не от бота, либо бот получил ответ/активность => можно слать новое сообщение
    const reflection = chatState.reflection || "";
    const newMessageText = generatePeriodicMessage(reflection, chatState);
    await sendMessage(chatId, newMessageText);
    
    // Обновляем состояние после отправки
    chatState.lastBotMessageTime = Date.now();
    chatState.lastMessageFromBot = true;
    // Обновляем "размышления" – например, бот обнуляет или формирует новое на основе реакции
    chatState.reflection = updateReflectionAfterSending(reflection, newMessageText);
    await CHAT_KV.put(entry.name, JSON.stringify(chatState));
  }
}
```

**Что делает этот код:**

- Итерируется по всем сохраненным чатам. 
- Для каждого проверяется, не было ли у бота последним слово без ответа. Если бот “разговаривает сам с собой” (т.е. его последнее сообщение повисло в пустоте), он **не будет** генерировать новое сообщение (`continue`). Благодаря этому условию, бот не заспамит молчащий чат: он дождется, когда кто-то что-то напишет. Как только в чат прилетит любое новое сообщение от пользователя (тем самым обновится `lastUserMessageTime` и `lastMessageFromBot` станет false), при следующем срабатывании cron бот снова активируется.
- Если же последнее сообщение было от пользователя **или** бот получил ответ/реплику после своего предыдущего поста, бот формирует новое **периодическое сообщение**. Содержание можно придумать на основе `reflection` или других данных. (Реализация `generatePeriodicMessage` зависит от задачи: например, бот может вести небольшую беседу сам с собой, либо напоминать о чем-то через равные интервалы.)
- Бот отправляет сообщение в чат (`sendMessage(chatId, text)` – та же функция отправки через Telegram API).
- Затем бот обновляет свое сохраненное состояние в KV: отмечает время отправки и факт, что последнее сообщение теперь от него, а также обновляет "размышления". **Пример обновления размышлений:** если бот задал вопрос и ожидает ответ, можно записать в размышления что-то вроде: *"спросил про погоду, жду ответа"*; если бот просто поделился фактом, можно очистить или изменить размышление под следующую тему.

Таким образом, с каждым запуском по расписанию бот принимает решение – говорить или молчать – исходя из активности в чате и своей «памяти» о предыдущих попытках.

## Итоговая структура решения

- **Cloudflare Worker** на TypeScript с библиотекой Telegraf, развернутый в режиме webhook. Бот регистрирует webhook URL с помощью BotFather (или скриптом, аналогично шаг ([[Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=,5%3A%20Configure%20Telegram%20Webhook)](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=,5%3A%20Configure%20Telegram%20Webhook))】).
- **Обработка входящих сообщений:** Worker (через Telegraf или вручную) получает обновления, сохраняет каждое сообщение в хранилище (KV/D1) с привязкой к `chat_id`, обновляет время последней активности. При упоминании бота – формирует и отправляет ответ, обновляя состояние.
- **Хранение состояния:** Используется KV (и/или D1) для хранения информации по каждому чату:
  - временные метки последнего сообщения от пользователя и от бота,
  - флаг, кто был автором последнего сообщения,
  - текстовые "размышления" бота (произвольные заметки или контекст).
- **Периодическая логика:** С помощью **Scheduled Triggers** Cloudflare запускает бот раз в 30 минут. Бот просматривает состояния всех чатов:
  - Если бот ранее написал и ему не ответили в течение 30 минут, он **пропускает** отправку (ждет пользовательского сообщения).
  - Иначе бот **отправляет** новое сообщение от себя и обновляет "размышления".
- **Пример поведения:** допустим, бот настроен каждые 30 минут присылать шутку. Если в каком-то чате в 12:00 бот рассказал шутку, но до 12:30 никто ничего не написал, то в 12:30 бот **не будет** рассказывать новую (чтобы не идти монологом). Он дождется, например, до 14:00, когда в чат кто-то что-то напишет; после этого, на ближайшем запуске (14:30) бот снова вставит свою реплику.

Такое решение использует бессерверную природу Cloudflare Workers: бот масштабируется автоматически, **не требует постоянного сервера**, а периодические задачи выполняются Cloudflare по расписани ([[Cron Triggers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule)](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule))】. Хранение на Workers KV/D1 обеспечивает сохранность контекста между вызовами. Вся логика (упоминания, паузы в ожидании ответа, размышления) инкапсулирована в коде Workers. 

**Диаграмма взаимодействия (общая):**

1. **Пользовательское сообщение →** Telegram пересылает обновление на ваш Cloudflare Worker (webhook).
2. **Cloudflare Worker (fetch) →** сохраняет сообщение в KV/D1, обновляет состояние. Если необходимо – отправляет ответ через Telegram API.
3. **Cloudflare Worker (scheduled trigger каждые 30 мин) →** просматривает состояния чатовых сессий:
   - решает, куда отправить сообщение согласно логике,
   - отправляет сообщения через Telegram API от имени бота.
4. **Telegram** доставляет эти бот-сообщения в чаты. (Замечание: бот не получает webhook на собственные сообщения, поэтому обновляет своё состояние локально.)
5. **Цикл повторяется...** Пользовательская активность сбрасывает таймер ожидания, бот реагирует упоминаниями немедленно и периодически – по расписанию с учетом условий.

Используя данный подход, мы получаем неблокирующего Telegram-бота, работающего полностью в серверless-среде. Он **присутствует в чатах** и ведет историю сообщений, **отвечает на упоминания** через Telegraf-контекст или прямые вызовы API, а также способен **инициировать сообщения** по таймеру, не нарушая удобство общения (благодаря проверке на отсутствие ответа). Все это реализовано средствами Cloudflare Workers, что обеспечивает высокую масштабируемость и отсутствие необходимости управлять собственным сервером.

**Источники:**

- Cloudflare Workers Cron Triggers – документация по запуску задач по расписани ([[Cron Triggers · Cloudflare Workers docs](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule)](https://developers.cloudflare.com/workers/configuration/cron-triggers/#:~:text=Cron%20Triggers%20allow%20users%20to,be%20executed%20on%20a%20schedule))】  
- Пример Telegram-бота на Cloudflare Workers с хранением данных в KV и D ([[Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=if%20%28pathname%20%3D%3D%3D%20%27%2Fwebhook%27%29%20,%27Hello%20from%20Cloudflare%20Workers)](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=if%20%28pathname%20%3D%3D%3D%20%27%2Fwebhook%27%29%20,%27Hello%20from%20Cloudflare%20Workers)) ([[Unlocking the Potential of Cloudflare Workers for Small Projects - DEV Community](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text)](https://dev.to/00geekinside00/unlocking-the-potential-of-cloudflare-workers-for-small-projects-45d0#:~:text=const%20response%20%3D%20await%20fetch,chat_id%3A%20chatId%2C%20text%3A%20text))】 (иллюстрирует обработку webhook и отправку сообщений).