### PR TITLE
fix: Correctly slice conversation history

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -151,8 +151,8 @@ export async function createBot(env: Env, webhookReply = false) {
         userMessages: [
           newMessage,
           ...(botHistory.text && shouldReply ? [botHistory] : []),
-          ...sessionData.userMessages.slice(0, 20)
-        ]
+          ...sessionData.userMessages
+        ].slice(-20)
       })
 
       const asyncActions = responseMessages.map(async ({ content, type }) => {


### PR DESCRIPTION
The previous implementation was slicing the beginning of the userMessages array, which caused the bot to forget recent messages and repeat old topics. This change corrects the slicing to take the last 20 messages, ensuring the bot has the most recent context.