### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,11 @@ Follow the existing log: short, imperative subjects (e.g., `turn off image gener
 ## Security & Configuration Tips
 
 Store secrets with `wrangler secret put` or in `.env.local`; never commit tokens. Double-check `scripts/setup-webhook.js` and `DEV_WEBHOOK_URL` in `.env` before running `webhook:set-dev`. Remove temporary tunnel URLs when promoting to production and rotate API keys if they were exposed during debugging.
+
+## Cursor Cloud specific instructions
+
+- **Dev server**: Run `npx wrangler dev --local` to start the Cloudflare Worker locally on `http://localhost:8787`. The `--local` flag avoids needing a Cloudflare account. The root `/` and `/health` endpoints return `OK`. The `/admin?dev=1` endpoint serves the admin panel in dev mode (bypasses Telegram auth).
+- **All external APIs are mocked in tests**: `pnpm test` requires no API keys, Cloudflare account, or external services. All 453+ tests pass out of the box.
+- **Webhook POST without secrets**: Sending a Telegram update POST to `/` will return `400 Invalid request` when `BOT_TOKEN` is not configured — this is expected. The worker initialises the Telegraf bot using `BOT_TOKEN` from the environment, so real webhook handling requires the secret.
+- **Pre-commit hook** runs `lint-staged` (ESLint + Prettier). **Pre-push hook** runs `pnpm typecheck`. Both are installed by Husky via `pnpm install`.
+- **Node.js 22** is required (see `.nvmrc`). The VM snapshot already has it via nvm.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable dev-environment guidance for future cloud agents.

## Type of Change

- [x] Documentation update

## Changes Made

- Added instructions for running the dev server locally with `npx wrangler dev --local`
- Documented that all external APIs are mocked in tests (no secrets needed)
- Noted expected 400 behavior when posting webhooks without `BOT_TOKEN`
- Documented pre-commit/pre-push hooks (lint-staged, typecheck)
- Noted Node.js 22 requirement

## Testing

- [x] All existing tests pass (`pnpm test` — 453 tests across 38 files)
- [x] Type checking passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)
- [x] Formatting passes (`pnpm format:check`)
- [x] Dev server starts and responds on `http://localhost:8787`
- [x] Admin panel loads at `/admin?dev=1`

## Walkthrough

[Admin panel in dev mode](https://cursor.com/agents/bc-a80f72bb-6fba-4593-850a-eeca397d37d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_panel_dev_mode.webp)
[Health check returning OK](https://cursor.com/agents/bc-a80f72bb-6fba-4593-850a-eeca397d37d7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhealth_check_ok.webp)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have run `pnpm typecheck` and it passes
- [x] I have run `pnpm lint` and there are no errors
- [x] I have run `pnpm format:check` and formatting is correct

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a80f72bb-6fba-4593-850a-eeca397d37d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a80f72bb-6fba-4593-850a-eeca397d37d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

